### PR TITLE
chore(testing): Update eslintrc for jest

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,3 @@
 {
-    "extends": ["./index.js"],
-    "env": {
-        "node": true
-    }
+    "extends": ["./index.js"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Jetbrains Software
+.idea/
+

--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ module.exports = {
         jest: true,
         node: true,
     },
+    "globals": {
+        "jestExpect": true,
+    },
     "parserOptions": {
         ecmaVersion: 2017,
         sourceType: "module",
@@ -23,5 +26,8 @@ module.exports = {
             generators: true,
             experimentalObjectRestSpread: true,
         },
+    },
+    "rules": {
+        "jest/valid-expect": "off",
     },
 };


### PR DESCRIPTION
Intent:
- Move some rules in `preamp-ui` to here for wider availability, and because the rules are related to React

Changes:
- Slight update to `.gitignore`
- Remove redundant rule in `.eslintrc`
- Add common jest global variable to "globals" list (`jestExpect`)
- Add `jest/valid-expect` rule

Notes:
- Should `jest/valid-expect` rule really be set to "off"?  This is how it was in `preamp-ui`
- Still a few more commits to push here, waiting on an update to `eslint-config-videoamp`