### PR TITLE
Update eslint-plugin-jsx-a11y to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint-config-videoamp": "^4.2.0",
     "eslint-plugin-css-modules": "^2.7.2",
     "eslint-plugin-jest": "^20.0.3",
-    "eslint-plugin-jsx-a11y": "^5.0.3",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0"
   },
   "peerDependencies": {

--- a/rules/plugins/react-a11y.js
+++ b/rules/plugins/react-a11y.js
@@ -15,6 +15,10 @@ module.exports = {
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md
         "jsx-a11y/anchor-has-content": ["error", { components: [""] }],
 
+        // Enforces that anchors navigate
+        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
+        "jsx-a11y/anchor-is-valid": "error",
+
         // Require ARIA roles to be valid and non-abstract
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md
         "jsx-a11y/aria-role": ["error", { ignoreNonDom: false }],
@@ -31,10 +35,6 @@ module.exports = {
         // properties do not have those attributes.
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-unsupported-elements.md
         "jsx-a11y/aria-unsupported-elements": "error",
-
-        // disallow href "#"
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/href-no-hash.md
-        "jsx-a11y/href-no-hash": ["error", { components: ["a"] }],
 
         // Enforce that all elements that require alternative text have meaningful information
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,9 +45,9 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.5.0.tgz#85e3152cd8cc5bab18dbed61cd9c4fce54fa79c3"
+aria-query@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.0.tgz#4af10a1e61573ddea0cf3b99b51c52c05b424d24"
   dependencies:
     ast-types-flow "0.0.7"
 
@@ -382,11 +382,11 @@ eslint-plugin-jest@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-20.0.3.tgz#ec15eba6ac0ab44a67ebf6e02672ca9d7e7cba29"
 
-eslint-plugin-jsx-a11y@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.0.3.tgz#4a939f76ec125010528823331bf948cc573380b6"
+eslint-plugin-jsx-a11y@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.2.tgz#659277a758b036c305a7e4a13057c301cd3be73f"
   dependencies:
-    aria-query "^0.5.0"
+    aria-query "^0.7.0"
     array-includes "^3.0.3"
     ast-types-flow "0.0.7"
     axobject-query "^0.1.0"


### PR DESCRIPTION
Updates jsx-a11y to latest, it was out of date. One rule was deprecated which was updated in the PR and has similar behavior with a bit more configuration.