### PR TITLE
Update jsx-a11y/label-has-for rule to allow children

### DIFF
--- a/rules/plugins/react-a11y.js
+++ b/rules/plugins/react-a11y.js
@@ -52,7 +52,7 @@ module.exports = {
 
         // require that JSX labels use "htmlFor"
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
-        "jsx-a11y/label-has-for": ["error", { components: ["label"] }],
+        "jsx-a11y/label-has-for": ["error", { "allowChildren": true }],
 
         // require that mouseover/out come with focus/blur, for keyboard-only users
         // TODO: evaluate


### PR DESCRIPTION
We provide children to our labels in our component library, and this change keeps that rule the same from the v6 update.